### PR TITLE
added http://blog.crashdump.io/tag/erlang.html feed

### DIFF
--- a/erlang/config.ini
+++ b/erlang/config.ini
@@ -157,3 +157,6 @@ name = Elixir Dose
 
 [http://erladvisor.blogspot.com/feeds/posts/default/-/erlang]
 name = Eugene Shubin
+
+[http://blog.crashdump.io/feeds/tag-erlang.rss.xml]
+name = CrashDump.io


### PR DESCRIPTION
Hi,

We added generating rss feed for Erlang (actually any) tag on our blog. https://twitter.com/stevenproctor/status/552840430463614976

Thank you!
