### PR TITLE
Updating feed for VariousAndSundry.com/cs

### DIFF
--- a/erlang/config.ini
+++ b/erlang/config.ini
@@ -146,7 +146,7 @@ name = Saša Jurić
 [http://icanmakeitbetter.com/category/elixir/feed/]
 name = icanmakeitbetter
 
-[http://variousandsundry.com/cs/blog/categories/elixir/atom.xml]
+[feed://variousandsundry.com/cs/blog/category/programming/elixir/feed/]
 name = Augie De Blieck Jr.
 
 [http://sigma-star.com/blog/rss/tag/erlang]


### PR DESCRIPTION
The website moved to WordPress last month.  This is the new feed for "Elixir"-tagged items, including Core Elixir.
